### PR TITLE
Grunt 1.0 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt": "~0.4.5"
   },
   "peerDependencies": {
-    "grunt": "~0.4.5"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin"

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "^0.9.2",
-    "grunt-contrib-clean": "^0.5.0",
-    "grunt-contrib-nodeunit": "^0.3.3",
-    "grunt": "~0.4.5"
+    "grunt": "^1.0.0",
+    "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-contrib-nodeunit": "^1.0.0"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"
@@ -40,7 +40,7 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "strip-json-comments": "^1.0.4",
+    "strip-json-comments": "^2.0.1",
     "stylint": "^1.0.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   ],
   "dependencies": {
     "strip-json-comments": "^2.0.1",
-    "stylint": "^1.0.9"
+    "stylint": "^1.0.9",
+    "lodash": "^4.8.2"
   }
 }

--- a/tasks/stylint.js
+++ b/tasks/stylint.js
@@ -10,6 +10,7 @@
 
 var stylint = require('stylint');
 var stripJsonComments = require('strip-json-comments');
+var _ = require('lodash');
 
 module.exports = function (grunt) {
 
@@ -36,7 +37,7 @@ module.exports = function (grunt) {
         grunt.log.writeln(color('magenta', 'Could not parse config file.'));
         return false;
       }
-      options.config = grunt.util._.extend({}, config, options.config);
+      options.config = _.extend({}, config, options.config);
     }
 
     // Fail on empty files list


### PR DESCRIPTION
Updates all dependencies and devDependencies; also changes the peerDependencies to make this compatible with both grunt 0.4.x and 1.0.

Since grunt 1.0 deprecated `grunt.util._` in favor of directly requiring `lodash`, added `lodash` as a dependency.

Passes `npm test`.
